### PR TITLE
feat: add network, device, and eero data usage metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,12 @@ classifiers = [
     "Topic :: System :: Networking :: Monitoring",
 ]
 dependencies = [
-    "eero-api~=4.0",
+    "eero-api~=4.2",
     "prometheus-client>=0.19.0",
     "typer>=0.9.0",
     "rich>=13.0.0",
     "pyyaml>=6.0",
+    "tzdata>=2024.1",
 ]
 
 [project.optional-dependencies]

--- a/src/eero_exporter/cli.py
+++ b/src/eero_exporter/cli.py
@@ -351,6 +351,11 @@ def serve(
         "--include-profiles/--no-profiles",
         help="Include profile metrics",
     ),
+    include_data_usage: bool = typer.Option(
+        True,
+        "--data-usage/--no-data-usage",
+        help="Include data usage metrics (adds ~9 API calls per network per scrape)",
+    ),
 ) -> None:
     """Start the Prometheus metrics server."""
     setup_logging(log_level.upper())
@@ -368,6 +373,7 @@ def serve(
     config.log_level = log_level
     config.include_devices = include_devices
     config.include_profiles = include_profiles
+    config.include_data_usage = include_data_usage
 
     if session_file:
         config.session_file = session_file

--- a/src/eero_exporter/collector.py
+++ b/src/eero_exporter/collector.py
@@ -2,7 +2,9 @@
 
 import logging
 import time
+from datetime import UTC, datetime, timedelta
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from .eero_adapter import EeroAPIError, EeroAuthError, EeroClient
 from .metrics import (
@@ -24,6 +26,7 @@ from .metrics import (
     DEVICE_CONNECTED_TO_GATEWAY,
     DEVICE_CONNECTION_SCORE,
     DEVICE_CONNECTION_SCORE_BARS,
+    DEVICE_DATA_USAGE_BYTES,
     DEVICE_FIRST_SEEN_TIMESTAMP,
     DEVICE_FREQUENCY,
     DEVICE_INFO,
@@ -53,6 +56,7 @@ from .metrics import (
     EERO_CONNECTED_CLIENTS,
     EERO_CONNECTED_WIRED_CLIENTS,
     EERO_CONNECTED_WIRELESS_CLIENTS,
+    EERO_DATA_USAGE_BYTES,
     EERO_HEARTBEAT_OK,
     EERO_INFO,
     EERO_IS_GATEWAY,
@@ -98,6 +102,7 @@ from .metrics import (
     NETWORK_BLACKLISTED_DEVICES_COUNT,
     NETWORK_CLIENTS_COUNT,
     NETWORK_CUSTOM_DNS_ENABLED,
+    NETWORK_DATA_USAGE_BYTES,
     NETWORK_DHCP_RESERVATIONS_COUNT,
     NETWORK_DNS_CACHING_ENABLED,
     NETWORK_DNS_SERVER_COUNT,
@@ -182,12 +187,123 @@ def _parse_timestamp(timestamp_str: str | None) -> float | None:
     if not timestamp_str:
         return None
     try:
-        from datetime import datetime
-
         dt = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
         return dt.timestamp()
     except (ValueError, TypeError):
         return None
+
+
+def _get_timezone(timezone_data: Any) -> ZoneInfo:
+    """Resolve a network's timezone, falling back to UTC.
+
+    Args:
+        timezone_data: The ``timezone`` field from network details. May be a
+            dict (``{"value": ...}`` or ``{"name": ...}``), a plain string,
+            or None.
+
+    Returns:
+        A ZoneInfo for the network timezone, or UTC if it cannot be resolved.
+    """
+    timezone_name = "UTC"
+    if isinstance(timezone_data, dict):
+        timezone_name = str(timezone_data.get("value") or timezone_data.get("name") or "UTC")
+    elif timezone_data:
+        timezone_name = str(timezone_data)
+
+    try:
+        return ZoneInfo(timezone_name)
+    except (ZoneInfoNotFoundError, ValueError):
+        _LOGGER.debug("Unknown eero timezone %s; using UTC", timezone_name)
+        return ZoneInfo("UTC")
+
+
+def _data_usage_period_payload(
+    period: str,
+    timezone: ZoneInfo,
+    now: datetime | None = None,
+) -> tuple[str, str, dict[str, str]]:
+    """Build an eero data_usage request payload for the current calendar period.
+
+    Args:
+        period: One of ``"day"``, ``"week"``, or ``"month"``.
+        timezone: Network timezone used to anchor the period boundaries.
+        now: Reference time; defaults to the current time in ``timezone``.
+            Exposed for deterministic testing.
+
+    Returns:
+        A tuple of ``(period, cadence, payload)`` where ``payload`` carries the
+        ISO-8601 ``start``/``end`` (UTC), ``cadence``, and ``timezone`` fields.
+
+    Raises:
+        ValueError: If ``period`` is not a supported value.
+    """
+    if now is None:
+        now = datetime.now(timezone)
+
+    if period == "day":
+        start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        end = start + timedelta(days=1) - timedelta(seconds=1)
+        cadence = "hourly"
+    elif period == "week":
+        # eero activity weeks start on Sunday, matching the official app.
+        # weekday() is Mon=0..Sun=6; (weekday + 1) % 7 days back reaches the
+        # most recent Sunday, and correctly yields 0 when today is Sunday.
+        days_since_sunday = (now.weekday() + 1) % 7
+        start = now - timedelta(days=days_since_sunday)
+        start = start.replace(hour=0, minute=0, second=0, microsecond=0)
+        end = start + timedelta(weeks=1) - timedelta(seconds=1)
+        cadence = "daily"
+    elif period == "month":
+        start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        if start.month == 12:
+            next_month = start.replace(year=start.year + 1, month=1)
+        else:
+            next_month = start.replace(month=start.month + 1)
+        end = next_month - timedelta(seconds=1)
+        cadence = "daily"
+    else:
+        raise ValueError(f"Unsupported data usage period: {period}")
+
+    payload = {
+        "start": start.astimezone(UTC).replace(tzinfo=None).isoformat() + "Z",
+        "end": end.astimezone(UTC).replace(tzinfo=None).isoformat() + "Z",
+        "cadence": cadence,
+        "timezone": timezone.key,
+    }
+    return period, cadence, payload
+
+
+def _series_sum(series: dict[str, Any]) -> float | None:
+    """Return a usage series total, computing it from values when needed.
+
+    Args:
+        series: A single data_usage series object.
+
+    Returns:
+        The series total in bytes, or None if no numeric data is present.
+    """
+    value = series.get("sum")
+    if value is not None:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    values = series.get("values", [])
+    if not isinstance(values, list):
+        return None
+
+    total = 0.0
+    found = False
+    for item in values:
+        if not isinstance(item, dict) or item.get("value") is None:
+            continue
+        try:
+            total += float(item["value"])
+            found = True
+        except (TypeError, ValueError):
+            continue
+    return total if found else None
 
 
 def _frequency_to_band(frequency: int | None) -> str:
@@ -344,6 +460,7 @@ class EeroCollector:
         include_blacklist: bool = True,
         include_diagnostics: bool = True,
         include_insights: bool = True,
+        include_data_usage: bool = True,
         timeout: int = 30,
         cookie_file: str | None = None,
     ) -> None:
@@ -360,6 +477,7 @@ class EeroCollector:
             include_blacklist: Whether to collect blacklist metrics
             include_diagnostics: Whether to collect diagnostics metrics
             include_insights: Whether to collect insights metrics
+            include_data_usage: Whether to collect data usage metrics
             timeout: Request timeout in seconds
             cookie_file: Path to session/cookie file for authentication
         """
@@ -373,6 +491,7 @@ class EeroCollector:
         self._include_blacklist = include_blacklist
         self._include_diagnostics = include_diagnostics
         self._include_insights = include_insights
+        self._include_data_usage = include_data_usage
         self._timeout = timeout
         self._cookie_file = cookie_file
         self._last_collection_time: float = 0
@@ -539,6 +658,9 @@ class EeroCollector:
 
         if self._include_devices:
             await self._collect_device_metrics(client, network_id, network_name)
+
+        if self._include_data_usage:
+            await self._collect_data_usage_metrics(client, network_id, network_details)
 
         if self._include_profiles:
             await self._collect_profile_metrics(client, network_id)
@@ -1154,6 +1276,174 @@ class EeroCollector:
             PROFILE_DEVICES_COUNT.labels(
                 network_id=network_id, profile_id=profile_id, name=name
             ).set(len(devices))
+
+    async def _collect_data_usage_metrics(
+        self,
+        client: EeroClient,
+        network_id: str,
+        network_details: dict[str, Any],
+    ) -> None:
+        """Collect network, device, and eero-node data usage metrics.
+
+        Issues one request per period (day/week/month) for the network total,
+        plus per-device and per-eero breakdowns when device metrics are
+        enabled. Each request is independently guarded so a partial failure
+        (e.g. an account without data_usage support) degrades gracefully.
+        """
+        timezone = _get_timezone(network_details.get("timezone"))
+        for period in ("day", "week", "month"):
+            period_label, cadence, payload = _data_usage_period_payload(period, timezone)
+
+            try:
+                usage = await client.get_data_usage(network_id, payload)
+                EXPORTER_API_REQUESTS.labels(
+                    endpoint=f"data_usage_{period_label}", status="success"
+                ).inc()
+                self._set_network_data_usage(network_id, period_label, cadence, usage)
+            except EeroAPIError as e:
+                _LOGGER.debug(f"Failed to get {period_label} data usage: {e}")
+                EXPORTER_API_REQUESTS.labels(
+                    endpoint=f"data_usage_{period_label}", status="error"
+                ).inc()
+
+            if not self._include_devices:
+                continue
+
+            try:
+                device_usage = await client.get_data_usage(network_id, payload, "devices")
+                EXPORTER_API_REQUESTS.labels(
+                    endpoint=f"data_usage_devices_{period_label}", status="success"
+                ).inc()
+                self._set_device_data_usage(network_id, period_label, cadence, device_usage)
+            except EeroAPIError as e:
+                _LOGGER.debug(f"Failed to get {period_label} device data usage: {e}")
+                EXPORTER_API_REQUESTS.labels(
+                    endpoint=f"data_usage_devices_{period_label}", status="error"
+                ).inc()
+
+            try:
+                eero_usage = await client.get_data_usage(network_id, payload, "eeros")
+                EXPORTER_API_REQUESTS.labels(
+                    endpoint=f"data_usage_eeros_{period_label}", status="success"
+                ).inc()
+                self._set_eero_data_usage(network_id, period_label, cadence, eero_usage)
+            except EeroAPIError as e:
+                _LOGGER.debug(f"Failed to get {period_label} eero data usage: {e}")
+                EXPORTER_API_REQUESTS.labels(
+                    endpoint=f"data_usage_eeros_{period_label}", status="error"
+                ).inc()
+
+    def _set_network_data_usage(
+        self,
+        network_id: str,
+        period: str,
+        cadence: str,
+        usage: dict[str, Any],
+    ) -> None:
+        """Set network-level data usage metrics from a data_usage response."""
+        series_list = usage.get("series", [])
+        if not isinstance(series_list, list):
+            return
+
+        for series in series_list:
+            if not isinstance(series, dict):
+                continue
+            direction = str(series.get("type") or series.get("direction") or "").lower()
+            if direction not in ("download", "upload"):
+                continue
+            total = _series_sum(series)
+            if total is None:
+                continue
+            NETWORK_DATA_USAGE_BYTES.labels(
+                network_id=network_id,
+                period=period,
+                cadence=cadence,
+                direction=direction,
+            ).set(total)
+
+    def _set_device_data_usage(
+        self,
+        network_id: str,
+        period: str,
+        cadence: str,
+        usage: dict[str, Any],
+    ) -> None:
+        """Set per-device data usage metrics from a data_usage response."""
+        values = usage.get("values", [])
+        if not isinstance(values, list):
+            return
+
+        for device in values:
+            if not isinstance(device, dict):
+                continue
+            device_id = str(device.get("id") or _extract_id_from_url(device.get("url", "")))
+            if not device_id:
+                continue
+            name = (
+                device.get("nickname")
+                or device.get("display_name")
+                or device.get("hostname")
+                or device.get("name")
+                or device_id
+            )
+            self._set_usage_direction_metrics(
+                DEVICE_DATA_USAGE_BYTES,
+                {
+                    "network_id": network_id,
+                    "device_id": device_id,
+                    "name": str(name),
+                    "period": period,
+                    "cadence": cadence,
+                },
+                device,
+            )
+
+    def _set_eero_data_usage(
+        self,
+        network_id: str,
+        period: str,
+        cadence: str,
+        usage: dict[str, Any],
+    ) -> None:
+        """Set per-eero-node data usage metrics from a data_usage response."""
+        values = usage.get("values", [])
+        if not isinstance(values, list):
+            return
+
+        for eero in values:
+            if not isinstance(eero, dict):
+                continue
+            eero_id = str(eero.get("id") or _extract_id_from_url(eero.get("url", "")))
+            if not eero_id:
+                continue
+            location = str(eero.get("location") or eero.get("name") or eero_id)
+            self._set_usage_direction_metrics(
+                EERO_DATA_USAGE_BYTES,
+                {
+                    "network_id": network_id,
+                    "eero_id": eero_id,
+                    "location": location,
+                    "period": period,
+                    "cadence": cadence,
+                },
+                eero,
+            )
+
+    def _set_usage_direction_metrics(
+        self,
+        metric: Any,
+        labels: dict[str, str],
+        usage: dict[str, Any],
+    ) -> None:
+        """Set download/upload values for a per-resource usage payload."""
+        for direction in ("download", "upload"):
+            value = usage.get(direction)
+            if value is None:
+                continue
+            try:
+                metric.labels(**labels, direction=direction).set(float(value))
+            except (TypeError, ValueError):
+                continue
 
     async def _collect_network_feature_flags(
         self,

--- a/src/eero_exporter/config.py
+++ b/src/eero_exporter/config.py
@@ -41,6 +41,7 @@ class ExporterConfig:
     # Metrics settings
     include_devices: bool = True
     include_profiles: bool = True
+    include_data_usage: bool = True
     include_speed_test: bool = False  # Off by default as it generates traffic
     speed_test_interval: int = 3600  # Run speed test every hour if enabled
 
@@ -84,6 +85,7 @@ class ExporterConfig:
             "session_file": str(self.session_file),
             "include_devices": self.include_devices,
             "include_profiles": self.include_profiles,
+            "include_data_usage": self.include_data_usage,
             "include_speed_test": self.include_speed_test,
             "speed_test_interval": self.speed_test_interval,
             "log_level": self.log_level,

--- a/src/eero_exporter/eero_adapter.py
+++ b/src/eero_exporter/eero_adapter.py
@@ -419,6 +419,38 @@ class EeroClient:
         return dict(_extract_data(raw_response))
 
     # =========================================================================
+    # Data Usage
+    # =========================================================================
+
+    @_wrap_api_call("Failed to get data usage")
+    async def get_data_usage(
+        self,
+        network_id: str,
+        payload: dict[str, Any],
+        resource: str | None = None,
+    ) -> dict[str, Any]:
+        """Get data usage for a network, its eero nodes, or its client devices.
+
+        Delegates to the eero-api ``get_data_usage`` facade method, available
+        since eero-api 4.2.0. The Eero cloud API expects the period request
+        fields (start, end, cadence, timezone) as a JSON body on a GET request.
+
+        Args:
+            network_id: Network identifier.
+            payload: Period request fields sent as the GET request body.
+            resource: Optional sub-resource, ``"devices"`` or ``"eeros"``.
+                Omit for network-level totals.
+
+        Returns:
+            Extracted data usage payload from the response envelope.
+        """
+        if not self._client:
+            raise EeroAPIError("Client not initialized. Use async context manager.")
+
+        raw_response = await self._client.get_data_usage(network_id, payload, resource)
+        return dict(_extract_data(raw_response))
+
+    # =========================================================================
     # SQM Settings
     # =========================================================================
 

--- a/src/eero_exporter/metrics.py
+++ b/src/eero_exporter/metrics.py
@@ -567,6 +567,33 @@ NETWORK_UPLOAD_BYTES = Counter(
 )
 
 # =============================================================================
+# DATA USAGE METRICS
+# =============================================================================
+
+# Source: eero API /networks/{id}/data_usage[/{resource}] endpoint.
+# The "period" label is one of day/week/month for the current calendar window;
+# "cadence" is the sample granularity eero used (hourly for day, daily otherwise);
+# "direction" is download or upload.
+
+NETWORK_DATA_USAGE_BYTES = Gauge(
+    f"{PREFIX}_network_data_usage_bytes",
+    "Network data usage in bytes from the eero data_usage endpoint for the current period.",
+    labelnames=["network_id", "period", "cadence", "direction"],
+)
+
+DEVICE_DATA_USAGE_BYTES = Gauge(
+    f"{PREFIX}_device_data_usage_bytes",
+    "Device data usage in bytes from the eero data_usage endpoint for the current period.",
+    labelnames=["network_id", "device_id", "name", "period", "cadence", "direction"],
+)
+
+EERO_DATA_USAGE_BYTES = Gauge(
+    f"{PREFIX}_eero_data_usage_bytes",
+    "Eero node data usage in bytes from the eero data_usage endpoint for the current period.",
+    labelnames=["network_id", "eero_id", "location", "period", "cadence", "direction"],
+)
+
+# =============================================================================
 # SQM (SMART QUEUE MANAGEMENT) METRICS
 # =============================================================================
 

--- a/src/eero_exporter/server.py
+++ b/src/eero_exporter/server.py
@@ -288,6 +288,7 @@ def run_server(config: ExporterConfig) -> None:
     collector = EeroCollector(
         include_devices=config.include_devices,
         include_profiles=config.include_profiles,
+        include_data_usage=config.include_data_usage,
         timeout=config.timeout,
         cookie_file=str(config.session_file),
     )

--- a/tests/test_data_usage.py
+++ b/tests/test_data_usage.py
@@ -1,0 +1,171 @@
+"""Tests for the data_usage feature: helpers, adapter wiring, upstream contract."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from zoneinfo import ZoneInfo
+
+import eero
+import pytest
+
+from eero_exporter.collector import (
+    _data_usage_period_payload,
+    _get_timezone,
+    _series_sum,
+)
+from eero_exporter.eero_adapter import EeroClient
+
+# ---------------------------------------------------------------------------
+# Upstream contract guard
+# ---------------------------------------------------------------------------
+
+
+def test_eero_client_exposes_get_data_usage() -> None:
+    """The pinned eero-api must expose the data_usage facade method.
+
+    Guards against an upstream rename/removal: the adapter delegates to
+    ``eero.EeroClient.get_data_usage``, added in eero-api 4.2.0.
+    """
+    assert hasattr(eero.EeroClient, "get_data_usage")
+
+
+# ---------------------------------------------------------------------------
+# _get_timezone
+# ---------------------------------------------------------------------------
+
+
+def test_get_timezone_from_dict_value() -> None:
+    assert _get_timezone({"value": "America/New_York"}).key == "America/New_York"
+
+
+def test_get_timezone_from_dict_name() -> None:
+    assert _get_timezone({"name": "Europe/London"}).key == "Europe/London"
+
+
+def test_get_timezone_from_string() -> None:
+    assert _get_timezone("America/Chicago").key == "America/Chicago"
+
+
+def test_get_timezone_unknown_falls_back_to_utc() -> None:
+    assert _get_timezone("Not/ARealZone").key == "UTC"
+
+
+def test_get_timezone_none_falls_back_to_utc() -> None:
+    assert _get_timezone(None).key == "UTC"
+
+
+def test_get_timezone_empty_dict_falls_back_to_utc() -> None:
+    assert _get_timezone({}).key == "UTC"
+
+
+# ---------------------------------------------------------------------------
+# _data_usage_period_payload
+# ---------------------------------------------------------------------------
+
+
+def test_day_period_payload() -> None:
+    now = datetime(2026, 1, 7, 15, 30, tzinfo=UTC)  # Wednesday
+    period, cadence, payload = _data_usage_period_payload("day", ZoneInfo("UTC"), now=now)
+    assert period == "day"
+    assert cadence == "hourly"
+    assert payload["start"] == "2026-01-07T00:00:00Z"
+    assert payload["end"] == "2026-01-07T23:59:59Z"
+    assert payload["cadence"] == "hourly"
+    assert payload["timezone"] == "UTC"
+
+
+def test_week_period_starts_on_sunday() -> None:
+    # 2026-01-07 is a Wednesday; the enclosing eero week starts Sun 2026-01-04.
+    now = datetime(2026, 1, 7, 9, 0, tzinfo=UTC)
+    _, cadence, payload = _data_usage_period_payload("week", ZoneInfo("UTC"), now=now)
+    assert cadence == "daily"
+    assert payload["start"] == "2026-01-04T00:00:00Z"
+    assert payload["end"] == "2026-01-10T23:59:59Z"
+
+
+def test_week_period_sunday_edge_case() -> None:
+    """When the reference day *is* Sunday, the week starts that same day.
+
+    Regression guard for the off-by-one where ``weekday() + 1`` shifted a
+    Sunday back a full week instead of to the start of the current week.
+    """
+    now = datetime(2026, 1, 4, 13, 45, tzinfo=UTC)  # Sunday
+    _, _, payload = _data_usage_period_payload("week", ZoneInfo("UTC"), now=now)
+    assert payload["start"] == "2026-01-04T00:00:00Z"
+    assert payload["end"] == "2026-01-10T23:59:59Z"
+
+
+def test_month_period_payload() -> None:
+    now = datetime(2026, 3, 17, 8, 0, tzinfo=UTC)
+    _, cadence, payload = _data_usage_period_payload("month", ZoneInfo("UTC"), now=now)
+    assert cadence == "daily"
+    assert payload["start"] == "2026-03-01T00:00:00Z"
+    assert payload["end"] == "2026-03-31T23:59:59Z"
+
+
+def test_month_period_december_rolls_to_next_year() -> None:
+    now = datetime(2026, 12, 10, 0, 0, tzinfo=UTC)
+    _, _, payload = _data_usage_period_payload("month", ZoneInfo("UTC"), now=now)
+    assert payload["start"] == "2026-12-01T00:00:00Z"
+    assert payload["end"] == "2026-12-31T23:59:59Z"
+
+
+def test_invalid_period_raises() -> None:
+    with pytest.raises(ValueError, match="Unsupported data usage period"):
+        _data_usage_period_payload("year", ZoneInfo("UTC"))
+
+
+# ---------------------------------------------------------------------------
+# _series_sum
+# ---------------------------------------------------------------------------
+
+
+def test_series_sum_uses_sum_field() -> None:
+    assert _series_sum({"sum": 1024}) == 1024.0
+
+
+def test_series_sum_computes_from_values() -> None:
+    series = {"values": [{"value": 10}, {"value": 20}, {"value": 5}]}
+    assert _series_sum(series) == 35.0
+
+
+def test_series_sum_skips_non_numeric_values() -> None:
+    series = {"values": [{"value": 10}, {"value": None}, {"value": "bad"}, {}]}
+    assert _series_sum(series) == 10.0
+
+
+def test_series_sum_empty_returns_none() -> None:
+    assert _series_sum({}) is None
+    assert _series_sum({"values": []}) is None
+
+
+def test_series_sum_invalid_sum_returns_none() -> None:
+    assert _series_sum({"sum": "not-a-number"}) is None
+
+
+# ---------------------------------------------------------------------------
+# Adapter delegation
+# ---------------------------------------------------------------------------
+
+
+async def test_adapter_get_data_usage_delegates_to_facade() -> None:
+    """The adapter forwards to the eero-api facade and unwraps the envelope."""
+    adapter = EeroClient()
+    facade = AsyncMock()
+    facade.get_data_usage = AsyncMock(
+        return_value={"meta": {"code": 200}, "data": {"series": [{"sum": 42}]}}
+    )
+    adapter._client = facade
+
+    result = await adapter.get_data_usage("net-1", {"cadence": "daily"}, "devices")
+
+    facade.get_data_usage.assert_awaited_once_with("net-1", {"cadence": "daily"}, "devices")
+    assert result == {"series": [{"sum": 42}]}
+
+
+async def test_adapter_get_data_usage_requires_initialized_client() -> None:
+    """Calling the adapter outside its context manager raises a clear error."""
+    from eero_exporter.eero_adapter import EeroAPIError
+
+    adapter = EeroClient()
+    with pytest.raises(EeroAPIError, match="Client not initialized"):
+        await adapter.get_data_usage("net-1", {})

--- a/uv.lock
+++ b/uv.lock
@@ -305,21 +305,21 @@ wheels = [
 
 [[package]]
 name = "eero-api"
-version = "4.1.2"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "keyring" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/25/b7ce59a6dcc8ca2c724952daf7b53a92de7367b360e08fa37a81b51a93c8/eero_api-4.1.2.tar.gz", hash = "sha256:913f89b456bdceef6beb128858d24eee80cf7daad061e2206bc72f6e606d4973", size = 38735, upload-time = "2026-05-11T17:49:57.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/ed/bda5ce2ab40ff072f59cece68f196ec0a3130f48a105b638a1cca01c3212/eero_api-4.2.0.tar.gz", hash = "sha256:40002fe8c84b641cc770bbedcde5ce1b78448614274040cbb148b42deaafd6f4", size = 39357, upload-time = "2026-05-18T03:05:00.435Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/ba/e6edbfe627a3d084f08fcd9a64b045a54d6fe65ca7c566491d8a75b88dd8/eero_api-4.1.2-py3-none-any.whl", hash = "sha256:7927cda5c00ebcd6deb012784d344cc6bde2c55a2840ada7555976d13c3c9b6e", size = 55548, upload-time = "2026-05-11T17:49:55.74Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/fe/7c4b9defa82c2b2749cea87fc8c26e31ff338ef6f39b5d66e2d2c8fb0f38/eero_api-4.2.0-py3-none-any.whl", hash = "sha256:ef6451651362a103de3e1322cb4e8da61afbb10d6efda3a4cbc7c3c3318ab013", size = 56910, upload-time = "2026-05-18T03:04:59.351Z" },
 ]
 
 [[package]]
 name = "eero-prometheus-exporter"
-version = "3.13.0"
+version = "3.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "eero-api" },
@@ -327,6 +327,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "typer" },
+    { name = "tzdata" },
 ]
 
 [package.optional-dependencies]
@@ -340,7 +341,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "eero-api", specifier = "~=4.0" },
+    { name = "eero-api", specifier = "~=4.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "prometheus-client", specifier = ">=0.19.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
@@ -350,6 +351,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "typer", specifier = ">=0.9.0" },
+    { name = "tzdata", specifier = ">=2024.1" },
 ]
 provides-extras = ["dev"]
 
@@ -1159,6 +1161,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]

--- a/wiki/Metrics.md
+++ b/wiki/Metrics.md
@@ -49,6 +49,20 @@ The exporter provides **120+ metrics** across 20+ categories.
 
 ---
 
+## 📦 Data Usage
+
+Sourced from the eero `data_usage` endpoint. Each gauge is reported for the
+current `day`, `week`, and `month` period, with a `direction` of `download`
+or `upload`. Collection can be disabled with `--no-data-usage`.
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `eero_network_data_usage_bytes` | Gauge | Network data usage for the current day/week/month |
+| `eero_device_data_usage_bytes` | Gauge | Per-device data usage for the current day/week/month |
+| `eero_eero_data_usage_bytes` | Gauge | Per-eero-node data usage for the current day/week/month |
+
+---
+
 ## 🚦 Network Feature Flags
 
 | Metric | Type | Description |


### PR DESCRIPTION
## Summary

Adds collection of the eero **`data_usage`** endpoint, exposing network-, device-, and eero-node-level usage totals as Prometheus metrics.

This consumes the first-class `data_usage` support added upstream in [`eero-api` PR #48](https://github.com/fulviofreitas/eero-api/pull/48) (merged, released as **eero-api 4.2.0**). The exporter calls it through the public `EeroClient.get_data_usage(network_id, payload, resource=None)` facade — no private-attribute access.

## What's included

- **Adapter** (`eero_adapter.py`): new `get_data_usage()` delegating to the eero-api facade and unwrapping the `{meta,data}` envelope, consistent with every other adapter method.
- **Metrics** (`metrics.py`): three new gauges — `eero_network_data_usage_bytes`, `eero_device_data_usage_bytes`, `eero_eero_data_usage_bytes` — labelled by `period` (day/week/month), `cadence`, and `direction` (download/upload).
- **Collector** (`collector.py`): `_collect_data_usage_metrics` gathers day/week/month totals per network with timezone-aware period windows. Each request is independently guarded, so accounts without `data_usage` support degrade gracefully (metric absent, no failed scrape).
- **Toggle**: new `include_data_usage` collector flag, surfaced as `--data-usage/--no-data-usage` and in `ExporterConfig` — matches the existing `--include-devices`/`--include-profiles` pattern and lets operators opt out of the extra API traffic.
- **Dependencies**: `eero-api ~=4.0` → `~=4.2` (4.2.0 is the minimum that exposes the facade); adds `tzdata` so `zoneinfo` resolves correctly in slim container images — this feature is the first `zoneinfo` consumer.
- **Tests** (`tests/test_data_usage.py`, 20 cases): cover the period-window, timezone, and series-sum helpers (including the Sunday week-start edge case), the adapter-to-facade delegation, and a contract guard asserting `eero.EeroClient` still exposes `get_data_usage`.
- **Docs**: `wiki/Metrics.md` gains a Data Usage section.

## Scrape-loop impact

With device metrics enabled, this adds up to **9 `GET /data_usage` requests per network per collection cycle** (3 periods × {network, devices, eeros}). The `--no-data-usage` flag exists to bound that for rate-limit-sensitive deployments. A future enhancement could collect data-usage on a slower sub-interval, since day/week/month totals move slowly.

## Relationship to #54

This adapts the data-usage collector design drafted in #54 and rebases it onto the now-merged eero-api facade — replacing the interim private-attribute access (`client._api.auth.get(...)`) with the public `get_data_usage` method. It also fixes the Sunday week-start off-by-one and adds the test coverage requested on that PR. #54 can be closed in favour of this once reviewed.

## Validation

`ruff check`, `ruff format --check`, `black --check`, `mypy` (`src/eero_exporter/`), and `pytest` (21 passed) all pass locally against eero-api 4.2.0.

Opened as a **draft** pending review.