### PR TITLE
fix: sync __version__ in __init__.py during semantic-release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -52,7 +52,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "echo ${nextRelease.version} > VERSION && sed -i 's/^version = \"[^\"]*\"/version = \"${nextRelease.version}\"/' pyproject.toml"
+        "prepareCmd": "echo ${nextRelease.version} > VERSION && sed -i 's/^version = \"[^\"]*\"/version = \"${nextRelease.version}\"/' pyproject.toml && sed -i 's/__version__ = \"[^\"]*\"/__version__ = \"${nextRelease.version}\"/' src/eero_exporter/__init__.py"
       }
     ],
     [
@@ -61,7 +61,8 @@
         "assets": [
           "CHANGELOG.md",
           "VERSION",
-          "pyproject.toml"
+          "pyproject.toml",
+          "src/eero_exporter/__init__.py"
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }

--- a/src/eero_exporter/__init__.py
+++ b/src/eero_exporter/__init__.py
@@ -1,4 +1,4 @@
 """Eero Prometheus Exporter - Modern metrics exporter for eero mesh WiFi networks."""
 
-__version__ = "2.2.3"
+__version__ = "3.16.0"
 __author__ = "Eero Exporter Team"


### PR DESCRIPTION
## Summary

- The release process rewrote `pyproject.toml` and `VERSION` on each release but never touched `src/eero_exporter/__init__.py`, leaving `__version__` frozen at `2.2.3` while the actual released version had reached `3.16.0`. The stale string surfaces in every CLI banner (`cli.py:60,154,212,275,389,403`) and on the server index page (`server.py:190`).
- Mirror the pattern used in [fulviofreitas/eero-api](https://github.com/fulviofreitas/eero-api/blob/master/.releaserc.json): extend the `@semantic-release/exec` `prepareCmd` with a second `sed` that rewrites `__version__`, and add `src/eero_exporter/__init__.py` to the `@semantic-release/git` `assets` list so it gets committed back with each release.
- Bump the in-tree value to `3.16.0` so the current release is correct without waiting for the next release cycle.

Closes #57

## Test plan

- [ ] CI passes (lint, type check, tests, Docker build)
- [ ] Next semantic-release run rewrites `__version__` in `src/eero_exporter/__init__.py` and commits it alongside `pyproject.toml`, `VERSION`, and `CHANGELOG.md`
- [ ] CLI banner (`eero-exporter --version`) and server index page show the bumped version after the release commit
