### PR TITLE
fix: coerce numeric fields from dict shapes in collector (#61)

### DIFF
--- a/src/eero_exporter/collector.py
+++ b/src/eero_exporter/collector.py
@@ -681,11 +681,15 @@ class EeroCollector:
                 try:
                     HEALTH_STATUS.labels(network_id=network_id, source="internet").set(is_healthy)
                 except Exception:
-                    _LOGGER.warning("Failed to set HEALTH_STATUS[internet] for network %s", network_id)
+                    _LOGGER.warning(
+                        "Failed to set HEALTH_STATUS[internet] for network %s", network_id
+                    )
             if eero_health:
                 is_healthy = 1 if eero_health.get("status") == "connected" else 0
                 try:
-                    HEALTH_STATUS.labels(network_id=network_id, source="eero_network").set(is_healthy)
+                    HEALTH_STATUS.labels(network_id=network_id, source="eero_network").set(
+                        is_healthy
+                    )
                 except Exception:
                     _LOGGER.warning(
                         "Failed to set HEALTH_STATUS[eero_network] for network %s", network_id
@@ -716,9 +720,7 @@ class EeroCollector:
                 except (ValueError, TypeError):
                     pass
                 except Exception:
-                    _LOGGER.warning(
-                        "Failed to set SPEED_TEST_TIMESTAMP for network %s", network_id
-                    )
+                    _LOGGER.warning("Failed to set SPEED_TEST_TIMESTAMP for network %s", network_id)
 
         await self._collect_network_feature_flags(client, network_id, network_name, network_details)
         await self._collect_sqm_metrics(client, network_id)
@@ -958,7 +960,9 @@ class EeroCollector:
                 except Exception:
                     _LOGGER.warning("Failed to set EERO_TEMPERATURE for eero %s", eero_id)
 
-            led_brightness = _coerce_numeric(eero.get("led_brightness"), field_name="led_brightness")
+            led_brightness = _coerce_numeric(
+                eero.get("led_brightness"), field_name="led_brightness"
+            )
             if led_brightness is not None:
                 try:
                     EERO_LED_BRIGHTNESS.labels(
@@ -1202,9 +1206,7 @@ class EeroCollector:
                             source_eero=source_eero,
                         ).set(signal_avg)
                     except Exception:
-                        _LOGGER.warning(
-                            "Failed to set DEVICE_SIGNAL_AVG for device %s", device_id
-                        )
+                        _LOGGER.warning("Failed to set DEVICE_SIGNAL_AVG for device %s", device_id)
 
                 score = _coerce_numeric(connectivity.get("score"), field_name="score")
                 if score is not None:
@@ -1251,9 +1253,7 @@ class EeroCollector:
                             source_eero=source_eero,
                         ).set(frequency)
                     except Exception:
-                        _LOGGER.warning(
-                            "Failed to set DEVICE_FREQUENCY for device %s", device_id
-                        )
+                        _LOGGER.warning("Failed to set DEVICE_FREQUENCY for device %s", device_id)
 
                 rx_bitrate = _parse_bitrate(connectivity.get("rx_bitrate"))
                 if rx_bitrate is not None:
@@ -1267,9 +1267,7 @@ class EeroCollector:
                             source_eero=source_eero,
                         ).set(rx_bitrate)
                     except Exception:
-                        _LOGGER.warning(
-                            "Failed to set DEVICE_RX_BITRATE for device %s", device_id
-                        )
+                        _LOGGER.warning("Failed to set DEVICE_RX_BITRATE for device %s", device_id)
 
                 rx_rate_info = connectivity.get("rx_rate_info", {})
                 if rx_rate_info and isinstance(rx_rate_info, dict):
@@ -1796,9 +1794,7 @@ class EeroCollector:
                 try:
                     SQM_UPLOAD_BANDWIDTH.labels(network_id=network_id).set(upload_bw)
                 except Exception:
-                    _LOGGER.warning(
-                        "Failed to set SQM_UPLOAD_BANDWIDTH for network %s", network_id
-                    )
+                    _LOGGER.warning("Failed to set SQM_UPLOAD_BANDWIDTH for network %s", network_id)
 
             download_bw = _coerce_numeric(
                 sqm_settings.get("download_bandwidth"), field_name="download_bandwidth"

--- a/src/eero_exporter/collector.py
+++ b/src/eero_exporter/collector.py
@@ -306,6 +306,56 @@ def _series_sum(series: dict[str, Any]) -> float | None:
     return total if found else None
 
 
+# Module-level set to deduplicate "unknown dict shape" DEBUG log entries.
+# Keyed by (field_name, sorted-keys-tuple) so we log only once per unique
+# field + key combination rather than every 5-minute scrape cycle.
+_COERCE_UNKNOWN_SHAPES_SEEN: set[tuple[str, tuple[str, ...]]] = set()
+
+_COERCE_DICT_KEYS = ("seconds", "value", "current", "total", "count")
+
+
+def _coerce_numeric(value: Any, field_name: str = "") -> float | None:
+    """Coerce a value of unknown type to float, handling dict shapes defensively.
+
+    The Eero Cloud API may change numeric fields from plain numbers to dicts
+    (e.g. ``uptime`` changed from ``int`` to ``{"seconds": N}``). This helper
+    normalises all plausible shapes so a schema migration on one field cannot
+    abort an entire collection cycle.
+
+    Args:
+        value: The raw value from the API response.
+        field_name: Name of the field (used for deduplicated DEBUG logging).
+
+    Returns:
+        The value as a float, or None if the value cannot be coerced.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    if isinstance(value, dict):
+        for key in _COERCE_DICT_KEYS:
+            if key in value:
+                return _coerce_numeric(value[key], field_name=field_name)
+        # No known key found — log once per (field_name, keys) combo.
+        sorted_keys = tuple(sorted(value.keys()))
+        dedup_key = (field_name, sorted_keys)
+        if dedup_key not in _COERCE_UNKNOWN_SHAPES_SEEN:
+            _COERCE_UNKNOWN_SHAPES_SEEN.add(dedup_key)
+            _LOGGER.debug(
+                "Cannot coerce dict to numeric for field %r: unknown keys %s",
+                field_name,
+                sorted_keys,
+            )
+        return None
+    return None
+
+
 def _frequency_to_band(frequency: int | None) -> str:
     """Convert frequency in MHz to WiFi band label.
 
@@ -628,10 +678,18 @@ class EeroCollector:
             eero_health = health.get("eero_network", {})
             if internet_health:
                 is_healthy = 1 if internet_health.get("status") == "connected" else 0
-                HEALTH_STATUS.labels(network_id=network_id, source="internet").set(is_healthy)
+                try:
+                    HEALTH_STATUS.labels(network_id=network_id, source="internet").set(is_healthy)
+                except Exception:
+                    _LOGGER.warning("Failed to set HEALTH_STATUS[internet] for network %s", network_id)
             if eero_health:
                 is_healthy = 1 if eero_health.get("status") == "connected" else 0
-                HEALTH_STATUS.labels(network_id=network_id, source="eero_network").set(is_healthy)
+                try:
+                    HEALTH_STATUS.labels(network_id=network_id, source="eero_network").set(is_healthy)
+                except Exception:
+                    _LOGGER.warning(
+                        "Failed to set HEALTH_STATUS[eero_network] for network %s", network_id
+                    )
 
         # Check for speedtest data - eero-api returns "speed_test", but older versions
         # or direct API calls may return "speed"
@@ -640,9 +698,15 @@ class EeroCollector:
             upload = speed.get("up", {})
             download = speed.get("down", {})
             if upload and "value" in upload:
-                SPEED_UPLOAD_MBPS.labels(network_id=network_id).set(upload["value"])
+                try:
+                    SPEED_UPLOAD_MBPS.labels(network_id=network_id).set(upload["value"])
+                except Exception:
+                    _LOGGER.warning("Failed to set SPEED_UPLOAD_MBPS for network %s", network_id)
             if download and "value" in download:
-                SPEED_DOWNLOAD_MBPS.labels(network_id=network_id).set(download["value"])
+                try:
+                    SPEED_DOWNLOAD_MBPS.labels(network_id=network_id).set(download["value"])
+                except Exception:
+                    _LOGGER.warning("Failed to set SPEED_DOWNLOAD_MBPS for network %s", network_id)
             if "date" in speed:
                 try:
                     from datetime import datetime
@@ -651,6 +715,10 @@ class EeroCollector:
                     SPEED_TEST_TIMESTAMP.labels(network_id=network_id).set(dt.timestamp())
                 except (ValueError, TypeError):
                     pass
+                except Exception:
+                    _LOGGER.warning(
+                        "Failed to set SPEED_TEST_TIMESTAMP for network %s", network_id
+                    )
 
         await self._collect_network_feature_flags(client, network_id, network_name, network_details)
         await self._collect_sqm_metrics(client, network_id)
@@ -757,37 +825,66 @@ class EeroCollector:
                 is_gateway
             )
 
-            clients_count = eero.get("connected_clients_count", 0)
-            EERO_CONNECTED_CLIENTS.labels(
-                network_id=network_id, eero_id=eero_id, location=location, model=model
-            ).set(clients_count)
+            clients_count = _coerce_numeric(
+                eero.get("connected_clients_count", 0), field_name="connected_clients_count"
+            )
+            try:
+                EERO_CONNECTED_CLIENTS.labels(
+                    network_id=network_id, eero_id=eero_id, location=location, model=model
+                ).set(clients_count or 0)
+            except Exception:
+                _LOGGER.warning("Failed to set EERO_CONNECTED_CLIENTS for eero %s", eero_id)
 
-            wired_clients = eero.get("connected_wired_clients_count")
+            wired_clients = _coerce_numeric(
+                eero.get("connected_wired_clients_count"),
+                field_name="connected_wired_clients_count",
+            )
             if wired_clients is not None:
-                EERO_CONNECTED_WIRED_CLIENTS.labels(
-                    network_id=network_id, eero_id=eero_id, location=location
-                ).set(wired_clients)
+                try:
+                    EERO_CONNECTED_WIRED_CLIENTS.labels(
+                        network_id=network_id, eero_id=eero_id, location=location
+                    ).set(wired_clients)
+                except Exception:
+                    _LOGGER.warning(
+                        "Failed to set EERO_CONNECTED_WIRED_CLIENTS for eero %s", eero_id
+                    )
 
-            wireless_clients = eero.get("connected_wireless_clients_count")
+            wireless_clients = _coerce_numeric(
+                eero.get("connected_wireless_clients_count"),
+                field_name="connected_wireless_clients_count",
+            )
             if wireless_clients is not None:
-                EERO_CONNECTED_WIRELESS_CLIENTS.labels(
-                    network_id=network_id, eero_id=eero_id, location=location
-                ).set(wireless_clients)
+                try:
+                    EERO_CONNECTED_WIRELESS_CLIENTS.labels(
+                        network_id=network_id, eero_id=eero_id, location=location
+                    ).set(wireless_clients)
+                except Exception:
+                    _LOGGER.warning(
+                        "Failed to set EERO_CONNECTED_WIRELESS_CLIENTS for eero %s", eero_id
+                    )
 
-            mesh_quality = eero.get("mesh_quality_bars")
+            mesh_quality = _coerce_numeric(
+                eero.get("mesh_quality_bars"), field_name="mesh_quality_bars"
+            )
             if mesh_quality is not None:
-                EERO_MESH_QUALITY.labels(
-                    network_id=network_id,
-                    eero_id=eero_id,
-                    location=location,
-                    model=model,
-                ).set(mesh_quality)
+                try:
+                    EERO_MESH_QUALITY.labels(
+                        network_id=network_id,
+                        eero_id=eero_id,
+                        location=location,
+                        model=model,
+                    ).set(mesh_quality)
+                except Exception:
+                    _LOGGER.warning("Failed to set EERO_MESH_QUALITY for eero %s", eero_id)
 
-            uptime = eero.get("uptime")
+            uptime = _coerce_numeric(eero.get("uptime"), field_name="uptime")
             if uptime is not None:
-                EERO_UPTIME_SECONDS.labels(
-                    network_id=network_id, eero_id=eero_id, location=location
-                ).set(uptime)
+                try:
+                    EERO_UPTIME_SECONDS.labels(
+                        network_id=network_id, eero_id=eero_id, location=location
+                    ).set(uptime)
+                except Exception:
+                    _LOGGER.warning("Failed to set EERO_UPTIME_SECONDS for eero %s", eero_id)
 
             led_on = eero.get("led_on")
             if led_on is not None:
@@ -814,60 +911,90 @@ class EeroCollector:
                 )
 
             # Try multiple field names for memory usage
-            memory_usage = eero.get("memory_usage")
+            memory_usage = _coerce_numeric(eero.get("memory_usage"), field_name="memory_usage")
             if memory_usage is None:
                 # Check nested structures
                 resources = eero.get("resources", {})
                 if isinstance(resources, dict):
-                    memory_usage = resources.get("memory_usage") or resources.get("memory_percent")
+                    memory_usage = _coerce_numeric(
+                        resources.get("memory_usage") or resources.get("memory_percent"),
+                        field_name="memory_usage",
+                    )
                 hardware = eero.get("hardware", {})
                 if isinstance(hardware, dict) and memory_usage is None:
-                    memory_usage = hardware.get("memory_usage") or hardware.get("memory_percent")
+                    memory_usage = _coerce_numeric(
+                        hardware.get("memory_usage") or hardware.get("memory_percent"),
+                        field_name="memory_usage",
+                    )
             if memory_usage is not None:
-                EERO_MEMORY_USAGE.labels(
-                    network_id=network_id, eero_id=eero_id, location=location
-                ).set(memory_usage)
+                try:
+                    EERO_MEMORY_USAGE.labels(
+                        network_id=network_id, eero_id=eero_id, location=location
+                    ).set(memory_usage)
+                except Exception:
+                    _LOGGER.warning("Failed to set EERO_MEMORY_USAGE for eero %s", eero_id)
 
             # Try multiple field names for temperature
-            temperature = eero.get("temperature")
+            temperature = _coerce_numeric(eero.get("temperature"), field_name="temperature")
             if temperature is None:
                 # Check nested structures
                 resources = eero.get("resources", {})
                 if isinstance(resources, dict):
-                    temperature = resources.get("temperature") or resources.get("temp_celsius")
+                    temperature = _coerce_numeric(
+                        resources.get("temperature") or resources.get("temp_celsius"),
+                        field_name="temperature",
+                    )
                 hardware = eero.get("hardware", {})
                 if isinstance(hardware, dict) and temperature is None:
-                    temperature = hardware.get("temperature") or hardware.get("temp_celsius")
+                    temperature = _coerce_numeric(
+                        hardware.get("temperature") or hardware.get("temp_celsius"),
+                        field_name="temperature",
+                    )
             if temperature is not None:
-                EERO_TEMPERATURE.labels(
-                    network_id=network_id, eero_id=eero_id, location=location
-                ).set(temperature)
+                try:
+                    EERO_TEMPERATURE.labels(
+                        network_id=network_id, eero_id=eero_id, location=location
+                    ).set(temperature)
+                except Exception:
+                    _LOGGER.warning("Failed to set EERO_TEMPERATURE for eero %s", eero_id)
 
-            led_brightness = eero.get("led_brightness")
+            led_brightness = _coerce_numeric(eero.get("led_brightness"), field_name="led_brightness")
             if led_brightness is not None:
-                EERO_LED_BRIGHTNESS.labels(
-                    network_id=network_id, eero_id=eero_id, location=location
-                ).set(led_brightness)
+                try:
+                    EERO_LED_BRIGHTNESS.labels(
+                        network_id=network_id, eero_id=eero_id, location=location
+                    ).set(led_brightness)
+                except Exception:
+                    _LOGGER.warning("Failed to set EERO_LED_BRIGHTNESS for eero %s", eero_id)
 
             last_reboot = eero.get("last_reboot")
             if last_reboot:
                 reboot_ts = _parse_timestamp(last_reboot)
                 if reboot_ts is not None:
-                    EERO_LAST_REBOOT.labels(
-                        network_id=network_id, eero_id=eero_id, location=location
-                    ).set(reboot_ts)
+                    try:
+                        EERO_LAST_REBOOT.labels(
+                            network_id=network_id, eero_id=eero_id, location=location
+                        ).set(reboot_ts)
+                    except Exception:
+                        _LOGGER.warning("Failed to set EERO_LAST_REBOOT for eero %s", eero_id)
 
             provides_wifi = eero.get("provides_wifi")
             if provides_wifi is not None:
-                EERO_PROVIDES_WIFI.labels(
-                    network_id=network_id, eero_id=eero_id, location=location
-                ).set(1 if provides_wifi else 0)
+                try:
+                    EERO_PROVIDES_WIFI.labels(
+                        network_id=network_id, eero_id=eero_id, location=location
+                    ).set(1 if provides_wifi else 0)
+                except Exception:
+                    _LOGGER.warning("Failed to set EERO_PROVIDES_WIFI for eero %s", eero_id)
 
             backup_connection = eero.get("backup_connection")
             if backup_connection is not None:
-                EERO_BACKUP_CONNECTION.labels(
-                    network_id=network_id, eero_id=eero_id, location=location
-                ).set(1 if backup_connection else 0)
+                try:
+                    EERO_BACKUP_CONNECTION.labels(
+                        network_id=network_id, eero_id=eero_id, location=location
+                    ).set(1 if backup_connection else 0)
+                except Exception:
+                    _LOGGER.warning("Failed to set EERO_BACKUP_CONNECTION for eero %s", eero_id)
 
             if self._include_ethernet:
                 await self._collect_ethernet_port_metrics(network_id, eero_id, location, eero)
@@ -876,31 +1003,53 @@ class EeroCollector:
             if nightlight and isinstance(nightlight, dict):
                 nl_enabled = nightlight.get("enabled")
                 if nl_enabled is not None:
-                    EERO_NIGHTLIGHT_ENABLED.labels(
-                        network_id=network_id, eero_id=eero_id, location=location
-                    ).set(1 if nl_enabled else 0)
+                    try:
+                        EERO_NIGHTLIGHT_ENABLED.labels(
+                            network_id=network_id, eero_id=eero_id, location=location
+                        ).set(1 if nl_enabled else 0)
+                    except Exception:
+                        _LOGGER.warning(
+                            "Failed to set EERO_NIGHTLIGHT_ENABLED for eero %s", eero_id
+                        )
 
-                nl_brightness = nightlight.get("brightness") or nightlight.get(
-                    "brightness_percentage"
+                nl_brightness = _coerce_numeric(
+                    nightlight.get("brightness") or nightlight.get("brightness_percentage"),
+                    field_name="nightlight_brightness",
                 )
                 if nl_brightness is not None:
-                    EERO_NIGHTLIGHT_BRIGHTNESS.labels(
-                        network_id=network_id, eero_id=eero_id, location=location
-                    ).set(nl_brightness)
+                    try:
+                        EERO_NIGHTLIGHT_BRIGHTNESS.labels(
+                            network_id=network_id, eero_id=eero_id, location=location
+                        ).set(nl_brightness)
+                    except Exception:
+                        _LOGGER.warning(
+                            "Failed to set EERO_NIGHTLIGHT_BRIGHTNESS for eero %s", eero_id
+                        )
 
                 nl_ambient = nightlight.get("ambient_light_enabled")
                 if nl_ambient is not None:
-                    EERO_NIGHTLIGHT_AMBIENT_ENABLED.labels(
-                        network_id=network_id, eero_id=eero_id, location=location
-                    ).set(1 if nl_ambient else 0)
+                    try:
+                        EERO_NIGHTLIGHT_AMBIENT_ENABLED.labels(
+                            network_id=network_id, eero_id=eero_id, location=location
+                        ).set(1 if nl_ambient else 0)
+                    except Exception:
+                        _LOGGER.warning(
+                            "Failed to set EERO_NIGHTLIGHT_AMBIENT_ENABLED for eero %s", eero_id
+                        )
 
                 nl_schedule = nightlight.get("schedule", {})
                 if nl_schedule and isinstance(nl_schedule, dict):
                     schedule_enabled = nl_schedule.get("enabled")
                     if schedule_enabled is not None:
-                        EERO_NIGHTLIGHT_SCHEDULE_ENABLED.labels(
-                            network_id=network_id, eero_id=eero_id, location=location
-                        ).set(1 if schedule_enabled else 0)
+                        try:
+                            EERO_NIGHTLIGHT_SCHEDULE_ENABLED.labels(
+                                network_id=network_id, eero_id=eero_id, location=location
+                            ).set(1 if schedule_enabled else 0)
+                        except Exception:
+                            _LOGGER.warning(
+                                "Failed to set EERO_NIGHTLIGHT_SCHEDULE_ENABLED for eero %s",
+                                eero_id,
+                            )
 
     async def _collect_device_metrics(
         self, client: EeroClient, network_id: str, network_name: str
@@ -963,117 +1112,164 @@ class EeroCollector:
             )
 
             connected = device.get("connected", False)
-            DEVICE_CONNECTED.labels(
-                network_id=network_id,
-                device_id=device_id,
-                name=name,
-                mac=mac,
-                manufacturer=manufacturer,
-                device_type=device_type,
-                connection_type=connection_type,
-                source_eero=source_eero,
-            ).set(1 if connected else 0)
+            try:
+                DEVICE_CONNECTED.labels(
+                    network_id=network_id,
+                    device_id=device_id,
+                    name=name,
+                    mac=mac,
+                    manufacturer=manufacturer,
+                    device_type=device_type,
+                    connection_type=connection_type,
+                    source_eero=source_eero,
+                ).set(1 if connected else 0)
+            except Exception:
+                _LOGGER.warning("Failed to set DEVICE_CONNECTED for device %s", device_id)
 
             wireless = device.get("wireless", False)
-            DEVICE_WIRELESS.labels(
-                network_id=network_id,
-                device_id=device_id,
-                name=name,
-                manufacturer=manufacturer,
-                device_type=device_type,
-            ).set(1 if wireless else 0)
+            try:
+                DEVICE_WIRELESS.labels(
+                    network_id=network_id,
+                    device_id=device_id,
+                    name=name,
+                    manufacturer=manufacturer,
+                    device_type=device_type,
+                ).set(1 if wireless else 0)
+            except Exception:
+                _LOGGER.warning("Failed to set DEVICE_WIRELESS for device %s", device_id)
 
             blocked = device.get("blacklisted", False)
-            DEVICE_BLOCKED.labels(
-                network_id=network_id,
-                device_id=device_id,
-                name=name,
-                mac=mac,
-                manufacturer=manufacturer,
-            ).set(1 if blocked else 0)
+            try:
+                DEVICE_BLOCKED.labels(
+                    network_id=network_id,
+                    device_id=device_id,
+                    name=name,
+                    mac=mac,
+                    manufacturer=manufacturer,
+                ).set(1 if blocked else 0)
+            except Exception:
+                _LOGGER.warning("Failed to set DEVICE_BLOCKED for device %s", device_id)
 
             paused = device.get("paused", False)
-            DEVICE_PAUSED.labels(
-                network_id=network_id,
-                device_id=device_id,
-                name=name,
-                manufacturer=manufacturer,
-                device_type=device_type,
-            ).set(1 if paused else 0)
+            try:
+                DEVICE_PAUSED.labels(
+                    network_id=network_id,
+                    device_id=device_id,
+                    name=name,
+                    manufacturer=manufacturer,
+                    device_type=device_type,
+                ).set(1 if paused else 0)
+            except Exception:
+                _LOGGER.warning("Failed to set DEVICE_PAUSED for device %s", device_id)
 
             is_guest = device.get("is_guest", False)
-            DEVICE_IS_GUEST.labels(
-                network_id=network_id,
-                device_id=device_id,
-                name=name,
-                manufacturer=manufacturer,
-            ).set(1 if is_guest else 0)
+            try:
+                DEVICE_IS_GUEST.labels(
+                    network_id=network_id,
+                    device_id=device_id,
+                    name=name,
+                    manufacturer=manufacturer,
+                ).set(1 if is_guest else 0)
+            except Exception:
+                _LOGGER.warning("Failed to set DEVICE_IS_GUEST for device %s", device_id)
 
             if connectivity:
                 signal = _parse_signal_strength(connectivity.get("signal"))
                 if signal is not None:
-                    DEVICE_SIGNAL_STRENGTH.labels(
-                        network_id=network_id,
-                        device_id=device_id,
-                        name=name,
-                        manufacturer=manufacturer,
-                        band=band,
-                        source_eero=source_eero,
-                    ).set(signal)
+                    try:
+                        DEVICE_SIGNAL_STRENGTH.labels(
+                            network_id=network_id,
+                            device_id=device_id,
+                            name=name,
+                            manufacturer=manufacturer,
+                            band=band,
+                            source_eero=source_eero,
+                        ).set(signal)
+                    except Exception:
+                        _LOGGER.warning(
+                            "Failed to set DEVICE_SIGNAL_STRENGTH for device %s", device_id
+                        )
 
                 signal_avg = _parse_signal_strength(connectivity.get("signal_avg"))
                 if signal_avg is not None:
-                    DEVICE_SIGNAL_AVG.labels(
-                        network_id=network_id,
-                        device_id=device_id,
-                        name=name,
-                        manufacturer=manufacturer,
-                        band=band,
-                        source_eero=source_eero,
-                    ).set(signal_avg)
+                    try:
+                        DEVICE_SIGNAL_AVG.labels(
+                            network_id=network_id,
+                            device_id=device_id,
+                            name=name,
+                            manufacturer=manufacturer,
+                            band=band,
+                            source_eero=source_eero,
+                        ).set(signal_avg)
+                    except Exception:
+                        _LOGGER.warning(
+                            "Failed to set DEVICE_SIGNAL_AVG for device %s", device_id
+                        )
 
-                score = connectivity.get("score")
+                score = _coerce_numeric(connectivity.get("score"), field_name="score")
                 if score is not None:
-                    DEVICE_CONNECTION_SCORE.labels(
-                        network_id=network_id,
-                        device_id=device_id,
-                        name=name,
-                        manufacturer=manufacturer,
-                        connection_type=connection_type,
-                        source_eero=source_eero,
-                    ).set(score)
+                    try:
+                        DEVICE_CONNECTION_SCORE.labels(
+                            network_id=network_id,
+                            device_id=device_id,
+                            name=name,
+                            manufacturer=manufacturer,
+                            connection_type=connection_type,
+                            source_eero=source_eero,
+                        ).set(score)
+                    except Exception:
+                        _LOGGER.warning(
+                            "Failed to set DEVICE_CONNECTION_SCORE for device %s", device_id
+                        )
 
-                score_bars = connectivity.get("score_bars")
+                score_bars = _coerce_numeric(
+                    connectivity.get("score_bars"), field_name="score_bars"
+                )
                 if score_bars is not None:
-                    DEVICE_CONNECTION_SCORE_BARS.labels(
-                        network_id=network_id,
-                        device_id=device_id,
-                        name=name,
-                        manufacturer=manufacturer,
-                        connection_type=connection_type,
-                        source_eero=source_eero,
-                    ).set(score_bars)
+                    try:
+                        DEVICE_CONNECTION_SCORE_BARS.labels(
+                            network_id=network_id,
+                            device_id=device_id,
+                            name=name,
+                            manufacturer=manufacturer,
+                            connection_type=connection_type,
+                            source_eero=source_eero,
+                        ).set(score_bars)
+                    except Exception:
+                        _LOGGER.warning(
+                            "Failed to set DEVICE_CONNECTION_SCORE_BARS for device %s", device_id
+                        )
 
                 if frequency is not None:
-                    DEVICE_FREQUENCY.labels(
-                        network_id=network_id,
-                        device_id=device_id,
-                        name=name,
-                        manufacturer=manufacturer,
-                        band=band,
-                        source_eero=source_eero,
-                    ).set(frequency)
+                    try:
+                        DEVICE_FREQUENCY.labels(
+                            network_id=network_id,
+                            device_id=device_id,
+                            name=name,
+                            manufacturer=manufacturer,
+                            band=band,
+                            source_eero=source_eero,
+                        ).set(frequency)
+                    except Exception:
+                        _LOGGER.warning(
+                            "Failed to set DEVICE_FREQUENCY for device %s", device_id
+                        )
 
                 rx_bitrate = _parse_bitrate(connectivity.get("rx_bitrate"))
                 if rx_bitrate is not None:
-                    DEVICE_RX_BITRATE.labels(
-                        network_id=network_id,
-                        device_id=device_id,
-                        name=name,
-                        manufacturer=manufacturer,
-                        band=band,
-                        source_eero=source_eero,
-                    ).set(rx_bitrate)
+                    try:
+                        DEVICE_RX_BITRATE.labels(
+                            network_id=network_id,
+                            device_id=device_id,
+                            name=name,
+                            manufacturer=manufacturer,
+                            band=band,
+                            source_eero=source_eero,
+                        ).set(rx_bitrate)
+                    except Exception:
+                        _LOGGER.warning(
+                            "Failed to set DEVICE_RX_BITRATE for device %s", device_id
+                        )
 
                 rx_rate_info = connectivity.get("rx_rate_info", {})
                 if rx_rate_info and isinstance(rx_rate_info, dict):
@@ -1593,13 +1789,27 @@ class EeroCollector:
             sqm_settings = await client.get_sqm_settings(network_id)
             EXPORTER_API_REQUESTS.labels(endpoint="sqm", status="success").inc()
 
-            upload_bw = sqm_settings.get("upload_bandwidth")
+            upload_bw = _coerce_numeric(
+                sqm_settings.get("upload_bandwidth"), field_name="upload_bandwidth"
+            )
             if upload_bw is not None:
-                SQM_UPLOAD_BANDWIDTH.labels(network_id=network_id).set(upload_bw)
+                try:
+                    SQM_UPLOAD_BANDWIDTH.labels(network_id=network_id).set(upload_bw)
+                except Exception:
+                    _LOGGER.warning(
+                        "Failed to set SQM_UPLOAD_BANDWIDTH for network %s", network_id
+                    )
 
-            download_bw = sqm_settings.get("download_bandwidth")
+            download_bw = _coerce_numeric(
+                sqm_settings.get("download_bandwidth"), field_name="download_bandwidth"
+            )
             if download_bw is not None:
-                SQM_DOWNLOAD_BANDWIDTH.labels(network_id=network_id).set(download_bw)
+                try:
+                    SQM_DOWNLOAD_BANDWIDTH.labels(network_id=network_id).set(download_bw)
+                except Exception:
+                    _LOGGER.warning(
+                        "Failed to set SQM_DOWNLOAD_BANDWIDTH for network %s", network_id
+                    )
 
         except EeroAPIError as e:
             _LOGGER.debug(f"Failed to get SQM settings: {e}")

--- a/tests/test_collector_coercion.py
+++ b/tests/test_collector_coercion.py
@@ -1,0 +1,160 @@
+"""Unit tests for _coerce_numeric helper in collector.py.
+
+Tests cover:
+- Numeric passthrough (int, float)
+- String coercion
+- Dict shapes with common keys (seconds, value, current, total, count)
+- Unknown dict shapes returning None with deduplicated DEBUG logging
+- None and unsupported types returning None
+"""
+
+import logging
+
+import pytest
+
+from eero_exporter.collector import _COERCE_UNKNOWN_SHAPES_SEEN, _coerce_numeric
+
+
+# ========================== _coerce_numeric Tests ==========================
+
+
+class TestCoerceNumeric:
+    """Tests for _coerce_numeric() defensive coercion helper."""
+
+    def setup_method(self) -> None:
+        """Clear the dedup set before each test for isolation."""
+        _COERCE_UNKNOWN_SHAPES_SEEN.clear()
+
+    # --- Numeric passthrough ---
+
+    def test_int_returns_float(self) -> None:
+        """Integer input is cast to float."""
+        assert _coerce_numeric(123) == 123.0
+
+    def test_float_passthrough(self) -> None:
+        """Float input is returned as-is (as float)."""
+        assert _coerce_numeric(45.6) == 45.6
+
+    def test_zero_int(self) -> None:
+        """Zero integer is returned as 0.0."""
+        assert _coerce_numeric(0) == 0.0
+
+    def test_negative_number(self) -> None:
+        """Negative numbers are coerced correctly."""
+        assert _coerce_numeric(-10) == -10.0
+
+    # --- String coercion ---
+
+    def test_numeric_string_returns_float(self) -> None:
+        """String containing a number is parsed to float."""
+        assert _coerce_numeric("123") == 123.0
+
+    def test_float_string(self) -> None:
+        """String containing a float is parsed correctly."""
+        assert _coerce_numeric("45.6") == 45.6
+
+    def test_non_numeric_string_returns_none(self) -> None:
+        """Non-numeric string returns None."""
+        assert _coerce_numeric("not_a_number") is None
+
+    def test_empty_string_returns_none(self) -> None:
+        """Empty string returns None."""
+        assert _coerce_numeric("") is None
+
+    # --- Dict shapes ---
+
+    def test_dict_with_seconds_key(self) -> None:
+        """Dict with 'seconds' key is coerced to float."""
+        assert _coerce_numeric({"seconds": 999}) == 999.0
+
+    def test_dict_with_value_key(self) -> None:
+        """Dict with 'value' key is coerced to float."""
+        assert _coerce_numeric({"value": 5}) == 5.0
+
+    def test_dict_with_current_key(self) -> None:
+        """Dict with 'current' key is coerced, extra keys ignored."""
+        assert _coerce_numeric({"current": 7, "last_reboot": "2024-01-01T00:00:00Z"}) == 7.0
+
+    def test_dict_with_total_key(self) -> None:
+        """Dict with 'total' key is coerced to float."""
+        assert _coerce_numeric({"total": 42}) == 42.0
+
+    def test_dict_with_count_key(self) -> None:
+        """Dict with 'count' key is coerced to float."""
+        assert _coerce_numeric({"count": 3}) == 3.0
+
+    def test_dict_key_priority_seconds_over_value(self) -> None:
+        """'seconds' takes priority over 'value' when both present."""
+        assert _coerce_numeric({"seconds": 10, "value": 99}) == 10.0
+
+    def test_dict_with_unknown_keys_returns_none(self) -> None:
+        """Dict with no known keys returns None."""
+        assert _coerce_numeric({"unknown": "junk"}) is None
+
+    def test_dict_nested_numeric_value(self) -> None:
+        """Dict value that is itself numeric is recursively coerced."""
+        assert _coerce_numeric({"seconds": "500"}) == 500.0
+
+    # --- None and unsupported types ---
+
+    def test_none_returns_none(self) -> None:
+        """None input returns None."""
+        assert _coerce_numeric(None) is None
+
+    def test_list_returns_none(self) -> None:
+        """List input returns None."""
+        assert _coerce_numeric([1, 2, 3]) is None
+
+    def test_bool_returns_float(self) -> None:
+        """Bool is a subclass of int, so True->1.0 and False->0.0."""
+        assert _coerce_numeric(True) == 1.0
+        assert _coerce_numeric(False) == 0.0
+
+    # --- DEBUG log deduplication ---
+
+    def test_unknown_shape_logs_debug_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Unknown dict shape triggers a DEBUG log exactly once per field+keys combo."""
+        with caplog.at_level(logging.DEBUG, logger="eero_exporter.collector"):
+            _coerce_numeric({"unknown": "junk"}, field_name="uptime")
+            _coerce_numeric({"unknown": "junk"}, field_name="uptime")
+            _coerce_numeric({"unknown": "junk"}, field_name="uptime")
+
+        debug_records = [
+            r for r in caplog.records if r.levelno == logging.DEBUG and "uptime" in r.message
+        ]
+        assert len(debug_records) == 1, (
+            f"Expected exactly 1 DEBUG log for same field+keys, got {len(debug_records)}"
+        )
+
+    def test_unknown_shape_logs_separately_per_field(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Different field names each get their own deduplicated DEBUG log entry."""
+        with caplog.at_level(logging.DEBUG, logger="eero_exporter.collector"):
+            _coerce_numeric({"unknown": "junk"}, field_name="uptime")
+            _coerce_numeric({"unknown": "junk"}, field_name="temperature")
+
+        debug_records = [
+            r for r in caplog.records if r.levelno == logging.DEBUG and "unknown" in r.message
+        ]
+        assert len(debug_records) == 2
+
+    def test_unknown_shape_logs_separately_per_key_set(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Different key sets on same field each get one DEBUG log entry."""
+        with caplog.at_level(logging.DEBUG, logger="eero_exporter.collector"):
+            _coerce_numeric({"foo": 1}, field_name="uptime")
+            _coerce_numeric({"bar": 2}, field_name="uptime")
+            _coerce_numeric({"foo": 1}, field_name="uptime")  # duplicate — should NOT log again
+
+        debug_records = [
+            r for r in caplog.records if r.levelno == logging.DEBUG and "uptime" in r.message
+        ]
+        assert len(debug_records) == 2
+
+    def test_known_key_after_unknown_dict_cleared(self) -> None:
+        """Known-key dict coerces correctly regardless of dedup state."""
+        _COERCE_UNKNOWN_SHAPES_SEEN.add(("uptime", ("seconds",)))  # pre-populate
+        # Should still coerce correctly — dedup set only gates logging, not logic
+        assert _coerce_numeric({"seconds": 100}, field_name="uptime") == 100.0

--- a/tests/test_collector_coercion.py
+++ b/tests/test_collector_coercion.py
@@ -14,7 +14,6 @@ import pytest
 
 from eero_exporter.collector import _COERCE_UNKNOWN_SHAPES_SEEN, _coerce_numeric
 
-
 # ========================== _coerce_numeric Tests ==========================
 
 
@@ -122,9 +121,9 @@ class TestCoerceNumeric:
         debug_records = [
             r for r in caplog.records if r.levelno == logging.DEBUG and "uptime" in r.message
         ]
-        assert len(debug_records) == 1, (
-            f"Expected exactly 1 DEBUG log for same field+keys, got {len(debug_records)}"
-        )
+        assert (
+            len(debug_records) == 1
+        ), f"Expected exactly 1 DEBUG log for same field+keys, got {len(debug_records)}"
 
     def test_unknown_shape_logs_separately_per_field(
         self, caplog: pytest.LogCaptureFixture

--- a/wiki/Metrics.md
+++ b/wiki/Metrics.md
@@ -172,7 +172,7 @@ or `upload`. Collection can be disabled with `--no-data-usage`.
 | `eero_eero_connected_wired_clients_count` | Gauge | Wired clients per eero |
 | `eero_eero_connected_wireless_clients_count` | Gauge | Wireless clients per eero |
 | `eero_eero_mesh_quality_bars` | Gauge | Mesh quality (0-5 bars) |
-| `eero_eero_uptime_seconds` | Gauge | Device uptime in seconds |
+| `eero_eero_uptime_seconds` | Gauge | Device uptime in seconds (tolerates dict shape `{"seconds": N}` returned by recent Eero firmware) |
 | `eero_eero_led_on` | Gauge | LED status (1=on, 0=off) |
 | `eero_eero_update_available` | Gauge | Firmware update available |
 | `eero_eero_heartbeat_ok` | Gauge | Heartbeat status |


### PR DESCRIPTION
## Summary

Closes #61

**Root cause**: The Eero Cloud API changed the `uptime` field on `/2.2/networks/{id}/eeros` from a plain number (seconds) to a dict (e.g. `{"seconds": N}`). The `EERO_UPTIME_SECONDS.labels(...).set(uptime)` call passed the dict directly to Prometheus, raising `TypeError: float() argument must be a string or a real number, not 'dict'`. Because this exception was unhandled, the **entire collection cycle aborted** (`success=False`), losing all metrics for the network on every scrape — not just uptime.

**Approach**:
- Added `_coerce_numeric(value, field_name)` module-level helper that normalises `int | float | str | dict` to `float`, checking common dict keys (`seconds`, `value`, `current`, `total`, `count`) in priority order. Unknown dict shapes return `None` and emit a deduplicated DEBUG log (once per field+key-set combo) to avoid log spam every 5 minutes.
- Applied `_coerce_numeric` to the `uptime` call site and to other likely-to-migrate fields in `_collect_eero_metrics`: `connected_clients_count`, `connected_wired_clients_count`, `connected_wireless_clients_count`, `mesh_quality_bars`, `memory_usage`, `temperature`, `led_brightness`; also SQM `upload_bandwidth` / `download_bandwidth` in `_collect_sqm_metrics`; and `score` / `score_bars` in `_collect_device_metrics`.
- Wrapped each individual `METRIC.labels(...).set(value)` block across `_collect_eero_metrics`, `_collect_network_metrics`, `_collect_sqm_metrics`, and `_collect_device_metrics` in a tight `try/except Exception: _LOGGER.warning(...)` so a future schema change on a single field cannot abort the rest of the scrape.
- Updated `wiki/Metrics.md` with a note on `eero_eero_uptime_seconds` dict tolerance.

## Test plan

- [x] `_coerce_numeric(123)` → `123.0`
- [x] `_coerce_numeric("123")` → `123.0`
- [x] `_coerce_numeric({"seconds": 999})` → `999.0`
- [x] `_coerce_numeric({"value": 5})` → `5.0`
- [x] `_coerce_numeric({"current": 7, "last_reboot": "..."})` → `7.0`
- [x] `_coerce_numeric({"unknown": "junk"})` → `None`
- [x] `_coerce_numeric(None)` → `None`
- [x] `_coerce_numeric([1,2,3])` → `None`
- [x] Unknown-shape DEBUG log fires exactly once per field+keys combo (dedup verified)
- [x] Full test suite: **52 passed**, 0 failed